### PR TITLE
Add scraper for get insta users from biography using geomatch option

### DIFF
--- a/tinderbotz/helpers/geomatch.py
+++ b/tinderbotz/helpers/geomatch.py
@@ -2,7 +2,7 @@ from tinderbotz.helpers.storage_helper import StorageHelper
 
 class Geomatch:
 
-    def __init__(self, name, age, work, study, home, gender, bio, distance, passions, image_urls):
+    def __init__(self, name, age, work, study, home, gender, bio, distance, passions, image_urls, instagram):
         self.name = name
         self.age = age
         self.work = work
@@ -13,6 +13,7 @@ class Geomatch:
         self.bio = bio
         self.distance = distance
         self.image_urls = image_urls
+        self.instagram = instagram
 
         # create a unique id for this person
         self.id = "{}{}_{}".format(name, age, StorageHelper.id_generator(size=4))
@@ -48,6 +49,9 @@ class Geomatch:
     def get_image_urls(self):
         return self.image_urls
 
+    def get_instagram(self):
+        return self.instagram
+
     def get_id(self):
         return self.id
 
@@ -64,5 +68,6 @@ class Geomatch:
             "passions": self.get_passions(),
             "image_urls": self.image_urls,
             "images_by_hashes": self.images_by_hashes,
+            "instagram": self.get_instagram(),
         }
         return data

--- a/tinderbotz/helpers/geomatch_helper.py
+++ b/tinderbotz/helpers/geomatch_helper.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.by import By
 from selenium.common.exceptions import *
 from selenium.webdriver.common.action_chains import ActionChains
 import time
+import re
 from tinderbotz.helpers.xpaths import content
 
 class GeomatchHelper:
@@ -349,6 +350,71 @@ class GeomatchHelper:
             print(e)
 
         return image_urls
+
+    @staticmethod
+    def de_emojify(text):
+        """Remove emojis from a string
+        Args:
+            text (string): string with emojis or not
+        Returns:
+            string: recompile string without emojis
+        """
+        regrex_pattern = re.compile(
+            pattern="["
+                    u"\U0001F600-\U0001F64F"  # emoticons
+                    u"\U0001F300-\U0001F5FF"  # symbols & pictographs
+                    u"\U0001F680-\U0001F6FF"  # transport & map symbols
+                    u"\U0001F1E0-\U0001F1FF"  # flags (iOS)
+                    "]+",
+            flags=re.UNICODE,
+        )
+        return regrex_pattern.sub(r'', text)
+
+    def get_insta(self, text):
+        """Take the bio and read line by line to match if the description
+        contain an instagram user.
+        Args:
+            text (string): string with emojis or not
+        Returns:
+            ig (string): return valid instagram user.
+        """
+        if not text:
+            return None
+        valid_pattern = [
+            "@",
+            "ig-",
+            "ig",
+            "ig:",
+            "ing",
+            "ing:",
+            "instag",
+            "instag:",
+            "insta:",
+            "insta",
+            "inst",
+            "inst:",
+            "instagram",
+            "instagram:",
+        ]
+        description = text.rstrip().lower().strip()
+        description = description.split()
+        for x in range(len(description)):
+            ig = self.de_emojify(description[x])
+            if '@' in ig:
+                return ig.replace('@', '')
+            elif ig in valid_pattern:
+                if ':' in description[x + 1]:
+                    return description[x + 2]
+                else:
+                    return description[x + 1]
+            else:
+                try:
+                    ig = ig.split(':', 1)
+                    if ig[0] in valid_pattern:
+                        return ig[-1]
+                except:
+                    return None
+        return None
 
     def _get_home_page(self):
         self.browser.get(self.HOME_URL)

--- a/tinderbotz/session.py
+++ b/tinderbotz/session.py
@@ -1,6 +1,6 @@
 # Selenium: automation of browser
 from selenium import webdriver
-#from webdriver_manager.chrome import ChromeDriverManager
+# from webdriver_manager.chrome import ChromeDriverManager
 import undetected_chromedriver.v2 as uc
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -16,7 +16,6 @@ import requests
 import atexit
 from pathlib import Path
 
-
 # Tinderbotz: helper classes
 from tinderbotz.helpers.geomatch import Geomatch
 from tinderbotz.helpers.match import Match
@@ -31,8 +30,8 @@ from tinderbotz.helpers.constants_helper import Printouts
 from tinderbotz.helpers.xpaths import *
 from tinderbotz.addproxy import get_proxy_extension
 
-class Session:
 
+class Session:
     HOME_URL = "https://www.tinder.com/app/recs"
 
     def __init__(self, headless=False, store_session=True, proxy=None, user_data=False):
@@ -77,13 +76,13 @@ class Session:
         # Create empty profile to avoid annoying Mac Popup
         if store_session:
             if not user_data:
-            	user_data =  f"{Path().absolute()}/chrome_profile/"
+                user_data = f"{Path().absolute()}/chrome_profile/"
             if not os.path.isdir(user_data):
                 os.mkdir(user_data)
 
             Path(f'{user_data}First Run').touch()
             options.add_argument(f"--user-data-dir={user_data}")
-        
+
         options.add_argument("--start-maximized")
         options.add_argument('--no-first-run --no-service-autorun --password-store=basic')
         options.add_argument("--lang=en-GB")
@@ -106,12 +105,11 @@ class Session:
             else:
                 options.add_argument(f'--proxy-server=http://{proxy}')
 
-
         # Getting the chromedriver from cache or download it from internet
         print("Getting ChromeDriver ...")
-        self.browser = uc.Chrome(options=options) #ChromeDriverManager().install(),
-        #self.browser = webdriver.Chrome(options=options)
-        #self.browser.set_window_size(1250, 750)
+        self.browser = uc.Chrome(options=options)  # ChromeDriverManager().install(),
+        # self.browser = webdriver.Chrome(options=options)
+        # self.browser.set_window_size(1250, 750)
 
         # clear the console based on the operating system you're using
         os.system('cls' if os.name == 'nt' else 'clear')
@@ -122,7 +120,6 @@ class Session:
 
         self.started = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
         print("Started session: {}\n\n".format(self.started))
-
 
     # Setting a custom location
     def set_custom_location(self, latitude, longitude, accuracy="100%"):
@@ -240,7 +237,6 @@ class Session:
 
             self._print_liked_stats()
 
-
     def dislike(self, amount=1):
         if self._is_logged_in():
             helper = GeomatchHelper(browser=self.browser)
@@ -281,6 +277,7 @@ class Session:
 
             bio, passions = helper.get_bio_and_passions()
             image_urls = helper.get_image_urls(quickload)
+            instagram = helper.get_insta(bio)
             rowdata = helper.get_row_data()
             work = rowdata.get('work')
             study = rowdata.get('study')
@@ -288,7 +285,8 @@ class Session:
             distance = rowdata.get('distance')
             gender = rowdata.get('gender')
 
-            return Geomatch(name=name, age=age, work=work, gender=gender, study=study, home=home, distance=distance, bio=bio, passions=passions, image_urls=image_urls)
+            return Geomatch(name=name, age=age, work=work, gender=gender, study=study, home=home, distance=distance,
+                            bio=bio, passions=passions, image_urls=image_urls, instagram=instagram)
 
     def get_chat_ids(self, new=True, messaged=True):
         if self._is_logged_in():


### PR DESCRIPTION
This option allows to obtain the Instagram of the users when they leave their ig in the biography. Since tinder for privacy does not give you the users when they link their accounts.
Here are some examples of when the cases occur ->

_"Hi im Rose, follow me on insta:roseinsta."_
_"ig:roseinsta"_
_"follow me -> @roseinsta"_

The idea is with some valid patterns and regex. add it to the json that extracts all the metadata from the profile. Here some examples.
![Captura de pantalla 2022-06-30 184649](https://user-images.githubusercontent.com/53288078/176915115-cae0e34f-7402-4a94-baca-b6549418908c.png)
![fsd](https://user-images.githubusercontent.com/53288078/176915122-a32daec1-20a3-4784-856d-3dc74dbb738d.png)

Clean form in a db would look like this


![db](https://user-images.githubusercontent.com/53288078/176915649-f23fdb8c-0566-4cd7-bd19-5fbf4876f107.png)

